### PR TITLE
 dynamically resolve docker.sock permission denied issue in Jenkins agents

### DIFF
--- a/Dockerfile.agent-with-compose
+++ b/Dockerfile.agent-with-compose
@@ -1,12 +1,28 @@
+# FROM jenkins/inbound-agent:latest-jdk17
+
+# USER root
+
+# # Set host Docker GID
+# ARG DOCKER_GID=1001
+
+# RUN apt-get update && \
+#     apt-get install -y curl docker.io && \  
+#     curl -L "https://github.com/docker/compose/releases/download/v2.37.3/docker-compose-linux-x86_64" -o /usr/local/bin/docker-compose && \
+#     chmod +x /usr/local/bin/docker-compose && \
+#     groupadd -for -g ${DOCKER_GID} docker && \
+#     usermod -aG docker jenkins
+
+# USER jenkins
 FROM jenkins/inbound-agent:latest-jdk17
 
 USER root
 
 RUN apt-get update && \
-    apt-get install -y curl docker.io && \  
+    apt-get install -y curl docker.io && \
     curl -L "https://github.com/docker/compose/releases/download/v2.37.3/docker-compose-linux-x86_64" -o /usr/local/bin/docker-compose && \
-    chmod +x /usr/local/bin/docker-compose && \
-    groupadd -f docker && \
-    usermod -aG docker jenkins
+    chmod +x /usr/local/bin/docker-compose
 
-USER jenkins
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,6 +16,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.agent-with-compose
+      args:
+        DOCKER_GID: ${DOCKER_GID}
     container_name: jenkins-agent-01
     depends_on:
       jenkins-master:
@@ -44,6 +46,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.agent-with-compose
+      args:
+        DOCKER_GID: ${DOCKER_GID}
     container_name: jenkins-agent-02
     depends_on:
       jenkins-master:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+SOCK=/var/run/docker.sock
+
+if [ -S "$SOCK" ]; then
+  DOCKER_GID=$(stat -c '%g' "$SOCK")
+  if ! getent group docker >/dev/null; then
+    groupadd -g "$DOCKER_GID" docker
+  fi
+  usermod -aG docker jenkins
+fi
+
+exec gosu jenkins "$@"


### PR DESCRIPTION

- Replaced static DOCKER_GID usage with dynamic detection inside entrypoint.sh
- Modified Dockerfile.agent-with-compose to use entrypoint.sh
- Removed dependency on .env DOCKER_GID and platform-specific scripts
- Ensures jenkins user inside agent is added to the correct docker group at runtime
- Fixes: docker.sock permission denied errors in pipeline jobs