### PR TITLE
refactor: optimize Jenkins agent setup to avoid duplicate image builds

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,6 +19,7 @@ services:
       dockerfile: Dockerfile.agent-with-compose
       args:
         DOCKER_GID: ${DOCKER_GID}
+    image: jenkins-agent:custom
     container_name: jenkins-agent-01
     depends_on:
       jenkins-master:
@@ -44,11 +45,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
   jenkins-agent-2:
-    build:
-      context: .
-      dockerfile: Dockerfile.agent-with-compose
-      args:
-        DOCKER_GID: ${DOCKER_GID}
+    image: jenkins-agent:custom
     container_name: jenkins-agent-02
     depends_on:
       jenkins-master:


### PR DESCRIPTION
- Modified docker-compose.yml to use a shared image `jenkins-agent:custom`
- Removed redundant `build:` block from `jenkins-agent-2`
- Added `image:` tag to reuse the same agent image across both services
- Updated build instructions to use targeted or pre-tagged image builds
- Resolves disk and performance overhead caused by duplicate Docker image builds