### PR TITLE
feat(agent): add Node.js support to custom Jenkins  agent image

### DIFF
--- a/Dockerfile.agent-with-compose
+++ b/Dockerfile.agent-with-compose
@@ -2,11 +2,17 @@ FROM jenkins/inbound-agent:latest-jdk17
 
 USER root
 
+# Install Docker CLI and Docker Compose
 RUN apt-get update && \
     apt-get install -y curl docker.io && \
     curl -L "https://github.com/docker/compose/releases/download/v2.37.3/docker-compose-linux-x86_64" -o /usr/local/bin/docker-compose && \
     chmod +x /usr/local/bin/docker-compose
 
+# ✅ Install Node.js and npm (v20)
+
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install -y nodejs && \
+    node -v && npm -v
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -456,3 +456,38 @@ image: jenkins-agent:custom
 jenkins-agent-2:
 image: jenkins-agent:custom
 ...
+
+The `Dockerfile.agent-with-compose` file defines a Jenkins agent image that includes:
+
+- Docker CLI
+- Docker Compose
+- Node.js (v20) and npm (for running frontend/backend build steps)
+
+This agent enables Jenkins to:
+
+- Build and run Docker containers via Docker Compose
+- Run JavaScript/Node.js commands such as `npm install` or `npm run build` in the pipeline
+- Support frontend/backend projects written in JavaScript (e.g., React or Node.js apps)
+
+### Build the Custom Agent Image
+
+```bash
+docker-compose --env-file .env build --no-cache jenkins-agent-1
+```
+Why Node.js Is Needed
+In pipelines where Jenkins builds frontend or backend projects using npm, the agent must have Node.js and npm installed. Without these, stages like:
+
+sh 'npm install'
+sh 'npm run build'
+
+will fail with npm: not found.
+
+Base Image Used
+We start from jenkins/inbound-agent:latest-jdk17, and then install:
+
+1: Docker CLI
+
+2: Docker Compose (v2.37.3)
+
+3: Node.js 20.x via NodeSource
+


### PR DESCRIPTION
- Installed Node.js v20 and npm in Dockerfile.agent-with-compose
- Required for running `npm install` and `npm run build` in frontend/backend build stages
- Keeps agent compatible with JavaScript-based apps in Jenkins pipeline